### PR TITLE
Remove unused using directives in Enum extension files.

### DIFF
--- a/PhoneBook/Extensions/EnumExtensions.cs
+++ b/PhoneBook/Extensions/EnumExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel;
-
-namespace PhoneBook.Extensions;
+﻿namespace PhoneBook.Extensions;
 
 /// <summary>
 /// The EnumExtensions class provides extension methods for working with enums.

--- a/PhoneBook/Extensions/EnumTypeExtensions.cs
+++ b/PhoneBook/Extensions/EnumTypeExtensions.cs
@@ -1,5 +1,3 @@
-using System.ComponentModel;
-
 namespace PhoneBook.Extensions;
 
 /// <summary>


### PR DESCRIPTION
Cleaned up `EnumExtensions.cs` and `EnumTypeExtensions.cs` by removing unnecessary `using System.ComponentModel` directives. This reduces clutter and potential confusion in these files.